### PR TITLE
ANDROID: sdcardfs: Don't d_drop in d_revalidate

### DIFF
--- a/fs/sdcardfs/dentry.c
+++ b/fs/sdcardfs/dentry.c
@@ -51,7 +51,6 @@ static int sdcardfs_d_revalidate(struct dentry *dentry, struct nameidata *nd)
 	 * whether the base obbpath has been changed or not
 	 */
 	if (is_obbpath_invalid(dentry)) {
-		d_drop(dentry);
 		return 0;
 	}
 
@@ -72,7 +71,6 @@ static int sdcardfs_d_revalidate(struct dentry *dentry, struct nameidata *nd)
 		if (nd)
 			pathcpy(&nd->path, &ptmp);
 		if (err == 0) {
-			d_drop(dentry);
 			goto out;
 		}
 	}
@@ -80,14 +78,12 @@ static int sdcardfs_d_revalidate(struct dentry *dentry, struct nameidata *nd)
 	spin_lock(&lower_dentry->d_lock);
 	if (d_unhashed(lower_dentry)) {
 		spin_unlock(&lower_dentry->d_lock);
-		d_drop(dentry);
 		err = 0;
 		goto out;
 	}
 	spin_unlock(&lower_dentry->d_lock);
 
 	if (parent_lower_dentry != lower_cur_parent_dentry) {
-		d_drop(dentry);
 		err = 0;
 		goto out;
 	}
@@ -101,7 +97,6 @@ static int sdcardfs_d_revalidate(struct dentry *dentry, struct nameidata *nd)
 	}
 
 	if (!qstr_case_eq(&dentry->d_name, &lower_dentry->d_name)) {
-		__d_drop(dentry);
 		err = 0;
 	}
 
@@ -120,7 +115,6 @@ static int sdcardfs_d_revalidate(struct dentry *dentry, struct nameidata *nd)
 	if (inode) {
 		data = top_data_get(SDCARDFS_I(inode));
 		if (!data || data->abandoned) {
-			d_drop(dentry);
 			err = 0;
 		}
 		if (data)


### PR DESCRIPTION
After d_revalidate returns 0, the vfs will call
d_invalidate, which will call d_drop itself, along
with other cleanup.

Bug: 78262592
Change-Id: Idbb30e008c05d62edf2217679cb6a5517d8d1a2c
Signed-off-by: Daniel Rosenberg <drosen@google.com>
Signed-off-by: Kevin F. Haggerty <haggertk@lineageos.org>